### PR TITLE
fix: broken links

### DIFF
--- a/src/content/docs/guide/first-widget.mdx
+++ b/src/content/docs/guide/first-widget.mdx
@@ -6,7 +6,7 @@ sidebar:
 
 import { Aside, Tabs, TabItem } from "@astrojs/starlight/components";
 
-Assuming you have [Fabric installed](../introduction/installation-guide.mdx), it's time to write your first widget!
+Assuming you have [Fabric installed](../getting-started/installation-guide.mdx), it's time to write your first widget!
 
 ## The Basics
 
@@ -337,4 +337,4 @@ Here's the full code to create your simple status bar:
 Congratulations! 🎉 You've just created your first basic status bar using Fabric. After this tutorial you should end up with something that looks like this.
 ![Status Bar Example](/assets/first-widget-bar.png)
  
-For a more advanced bar example, check out [this example](github.com/Fabric-Development/fabric/tree/main/examples/bar).
+For a more advanced bar example, check out [this example](https://github.com/Fabric-Development/fabric/tree/main/examples/bar).


### PR DESCRIPTION
- Updated the link on line 9 in `first-widget.mdx` to point to the correct installation guide.
- Fixed the link on line 340 in `first-widget.mdx` by adding the full URL for the bar example.