### PR TITLE
docs: add Ubuntu 24.04 installation instructions

### DIFF
--- a/src/content/docs/getting-started/installation-guide.mdx
+++ b/src/content/docs/getting-started/installation-guide.mdx
@@ -45,6 +45,11 @@ import { Aside, Steps, Tabs, TabItem } from "@astrojs/starlight/components";
        gobject-introspection gobject-introspection-runtime python python-pip
        python-gobject python-cairo python-loguru pkgconf`
      </TabItem>
+     <TabItem label="Ubuntu 24.04">
+       * `sudo apt-get install build-essential pkg-config python3-cairo-dev
+       python3-dev python-is-python3python-dev-is-python3 cairo2-dev
+       gobject-introspection libgirepository-1.0-dev`
+     </TabItem>
      <TabItem label="OpenSUSE">
        _(tested on Tumbleweed)_
 


### PR DESCRIPTION
Add installation instructions for Ubuntu 24.04.

With a few caveats: 

- I haven't tested this from a clean VM, so the list might be incomplete. 
- I'm not sure how to rebuild the docs, so I might have broken the build. 

Other than that, this _should_ work. 