### PR TITLE
Update Hyprland layerrule to new syntax (Hyprland 0.53)

### DIFF
--- a/src/content/docs/getting-started/faq.mdx
+++ b/src/content/docs/getting-started/faq.mdx
@@ -55,8 +55,8 @@ If you're not on Hyprland, provide more information through a [GitHub issue](htt
 Add these lines to your Hyprland config:
 
 ```conf
-layerrule = blur, fabric.*
-layerrule = ignorezero, fabric.*
+layerrule = blur on, match:namespace fabric
+layerrule = ignore_alpha 0, match:namespace fabric
 ```
 
 ---


### PR DESCRIPTION
Updates the section 'My widget isn’t blurring its background on Hyprland' to use the new Layerrule syntax introduced in 0.53